### PR TITLE
[#99459014] Use `dpkg_package` when there is a custom `install_url`.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer        "edelight GmbH"
 maintainer_email  "markus.korn@edelight.de"
 license           "Apache 2.0"
 description       "Installs and configures mongodb"
-version           "0.987654321.22"
+version           "0.987654321.23"
 
 recipe "mongodb", "Installs and configures a single node mongodb instance"
 recipe "mongodb::10gen_repo", "Adds the 10gen repo to get the latest packages"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -31,33 +31,27 @@ if node[:mongodb][:install_url]
   # Include :install_url attribute to download from an alternate location
   remote_file "#{Chef::Config[:file_cache_path]}/mongodb-10gen.deb" do
     source node[:mongodb][:install_url]
-    notifies :install, "package[#{node[:mongodb][:package_name]}]", :immediately
   end
-end
-
-package node[:mongodb][:package_name] do
-  # `package_version` needs to be set whether install_url is nil or not.
-  # Without it, the resource will try to figure out version by looking up package name.
-  # If version doesn't match `source` file, it's ignored and new package is downloaded.
-  version node[:mongodb][:package_version]
-
-  if node[:mongodb][:install_url]
-    # With a custom install URL, the download task will notify this task when to run
-    action :nothing
-    source "#{Chef::Config[:file_cache_path]}/mongodb-10gen.deb"
-  else
+  dpkg_package 'mongodb-10gen' do
     action :install
+    source "#{Chef::Config[:file_cache_path]}/mongodb-10gen.deb"
+    version node[:mongodb][:package_version]
   end
-  
-  # The deb package automatically starts mongo, which breaks stuff.
-  # Stop it immediately, but only if something changed (i.e. install).
-  # Only been tested on ubuntu 12.04 (and also might only be an issue there).
-  if platform_family?("debian")
-    notifies :stop, "service[mongodb]", :immediately
-    notifies :disable, "service[mongodb]", :immediately
+else
+  # Without :install_url, install from the repository
+  package node[:mongodb][:package_name] do
+    action :install
+    version node[:mongodb][:package_version]
+
+    # The deb package automatically starts mongo, which breaks stuff.
+    # Stop it immediately, but only if something changed (i.e. install).
+    # Only been tested on ubuntu 12.04 (and also might only be an issue there).
+    if platform_family?("debian")
+      notifies :stop, "service[mongodb]", :immediately
+      notifies :disable, "service[mongodb]", :immediately
+    end
   end
 end
-
 
 # Create keyFile if specified
 if node[:mongodb][:key_file]

--- a/spec/install_spec.rb
+++ b/spec/install_spec.rb
@@ -16,7 +16,7 @@ describe 'mongodb::default' do
     expect(chef_run).to install_package('mongodb-10gen').with_version(expected_version)
   end
 
-  it 'if install_url is specified, it should create mongodb-10gen.deb file and notify mongodb pkg install' do
+  it 'if install_url is specified, it should create mongodb-10gen.deb file and install via dpkg' do
     expected_version = "#{rand(10)}.#{rand(10)}.#{rand(10)}"
     remote_file = "#{Chef::Config[:file_cache_path]}/mongodb-10gen.deb"
     install_url = "http://example.com/mongodb-10gen_2.4.9_amd64.deb"
@@ -25,9 +25,10 @@ describe 'mongodb::default' do
 
     chef_run.converge(described_recipe)
     expect(chef_run).to create_remote_file(remote_file).with(source: install_url)
-    resource = chef_run.remote_file(remote_file)
-    expect(resource).to notify('package[mongodb-10gen]').to(:install).immediately
-    expect(chef_run.package('mongodb-10gen').version).to eq expected_version
+    expect(chef_run).to install_dpkg_package('mongodb-10gen').with(
+      source: remote_file,
+      version: expected_version
+    )
   end
 
   # TODO: This is currently true in the above tests but appears to be a side


### PR DESCRIPTION
This works around a strange intermittent when using the `(apt_)package` resource with a custom `source` attribute to install; we noticed that sometimes Chef was reaching out to the remote repo even though the source was a local file.

I tried over 50 Chef runs in China using a custom `install_url` with this fix and never hit the issue mentioned in [PT#99459014](https://www.pivotaltracker.com/story/show/99459014), so hopefully this fix is legit.

https://www.pivotaltracker.com/story/show/99459014