### PR TITLE
[#106063082] Fix a problem that china side mongod in shard having problem config shards

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -36,6 +36,12 @@ if node[:mongodb][:install_url]
     action :install
     source "#{Chef::Config[:file_cache_path]}/mongodb-10gen.deb"
     version node[:mongodb][:package_version]
+
+    # The deb package automatically starts mongo, which breaks stuff.
+    # Stop it immediately, but only if something changed (i.e. install).
+    # Only been tested on ubuntu 12.04 (and also might only be an issue there).
+    notifies :stop, "service[mongodb]", :immediately
+    notifies :disable, "service[mongodb]", :immediately
   end
 else
   # Without :install_url, install from the repository


### PR DESCRIPTION
Notice in today when try rebuild 2 mongod in sandbox China in shard 2:

```
Recipe: mongodb::shard
  * template[/etc/default/shard] action create (up to date)
  * directory[/var/log/mongodb] action create (up to date)
  * directory[/var/lib/mongodb] action create (up to date)
  * template[/etc/init.d/shard] action create (up to date)
  * service[shard] action enable
    - enable service service[shard]

  * service[shard] action start
================================================================================
Error executing action `start` on resource 'service[shard]'
================================================================================


Mixlib::ShellOut::ShellCommandFailed
------------------------------------
Expected process to exit with [0], but received '1'
---- Begin output of /etc/init.d/shard start ----
STDOUT: ** Running shard (/usr/bin/mongod  --port 27017 --dbpath /var/lib/mongodb --logpath /var/log/mongodb/shard.log --replSet rs_shard2 --rest)
 * Starting database shard
   ...fail!
STDERR: 
---- End output of /etc/init.d/shard start ----
Ran /etc/init.d/shard start returned 1


Resource Declaration:
---------------------
# In /var/chef/cache/cookbooks/mongodb/definitions/mongodb.rb

152:   service name do
153:     supports :status => true, :restart => true
154:     action service_action
155:     service_notifies.each do |service_notify|
156:       notifies :run, service_notify
157:     end
158:     if !replicaset_name.nil? && node['mongodb']['auto_configure']['replicaset']
159:       notifies :create, "ruby_block[config_replicaset]"
160:     end
161:     if type == "mongos" && node['mongodb']['auto_configure']['sharding']



Compiled Resource:
------------------
# Declared in /var/chef/cache/cookbooks/mongodb/definitions/mongodb.rb:152:in `block in from_file'

service("shard") do
  params {:mongodb_type=>"shard", :action=>[:enable, :start], :bind_ip=>nil, :port=>27017, :logpath=>"/var/log/mongodb", :dbpath=>"/var/lib/mongodb", :configserver=>[], :replicaset=>node[ip-172-31-28-231.cn-north-1.compute.internal], :enable_rest=>true, :smallfiles=>false, :notifies=>[], :name=>"shard"}
  action [:enable, :start]
  updated true
  supports {:status=>true, :restart=>true}
  retries 0
  retry_delay 2
  service_name "shard"
  enabled true
  pattern "shard"
  startup_type :automatic
  cookbook_name "mongodb"
  recipe_name "shard"
end



  * ruby_block[config_replicaset] action create      ** Notice: The native BSON extension was not loaded. **

      For optimal performance, use of the BSON extension is recommended.

      To enable the extension make sure ENV['BSON_EXT_DISABLED'] is not set
      and run the following command:

        gem install bson_ext

      If you continue to receive this message after installing, make sure that
      the bson_ext gem is in your load path.

[2015-10-19T21:31:38+00:00] ERROR: Failed to configure replicaset, reason: {"ok"=>0.0, "errmsg"=>"server is not running with --replSet"}
```